### PR TITLE
mutliple icons branch init

### DIFF
--- a/cville_region_collection/cville_climate_update.Rmd
+++ b/cville_region_collection/cville_climate_update.Rmd
@@ -62,15 +62,32 @@ r <- img_uri("icons/risk.png")
 i <- img_uri("icons/infrastructure.png")
 e <- img_uri("icons/economic.png")
 
-table <- table %>% 
-  mutate(Icon = case_when(
-    Topics == "Climate measures" ~ c,
-    Topics == "Transportation" ~ t,
-    Topics == "Risk factors" ~ r,
-    Topics == "Community assets & infrastructure" ~ i,
-    Topics == "Social & economic characteristics" ~ e
-    )) %>% 
-  select(Topics, Icon, everything())
+########################## Multiple icons ##########################
+library(stringi)
+
+for (z in 1:nrow(table)) {
+  topic_vec <- unlist(stri_split(table[z, 'Topics'], regex = ', ')) # split up topics for data source
+  icon_vec <- sapply(topic_vec, function(x) case_when(x == "Climate measures" ~ c,
+                                                      x == "Transportation" ~ t,
+                                                      x == "Risk factors" ~ r,
+                                                      x == "Community assets & infrastructure" ~ i,
+                                                      x == "Social & economic characteristics" ~ e) # identify corresponding icons
+  )
+  icon_vec <- paste0(icon_vec, collapse = ', ') # paste the icon sources together
+  table[z, 'Icon'] <- icon_vec # add icons to table
+  table <- table %>% select(Topics, Icon, everything()) # reorder `Icon` to be 2nd column
+}
+####################################################################
+
+# table <- table %>% 
+#   mutate(Icon = case_when(
+#     Topics == "Climate measures" ~ c,
+#     Topics == "Transportation" ~ t,
+#     Topics == "Risk factors" ~ r,
+#     Topics == "Community assets & infrastructure" ~ i,
+#     Topics == "Social & economic characteristics" ~ e
+#     )) %>% 
+#   select(Topics, Icon, everything())
 
 # table <- table %>%
 #   separate(Tags, into = c("tag1", "tag2"))


### PR DESCRIPTION
Solution to question about printing multiple icons in `Icons` column for each data source.

This is intended as a replacement for the previous icon-assignment chunk (using `case_when()` within `mutate()`), which I've commented out in the pull request's code.

The default `Icon` column width will result in icons being stacked vertically. I found in some quick tests that a width of ~125px was sufficient to get two icons side by side in the rendered table.